### PR TITLE
Change sort order of upcoming meetups

### DIFF
--- a/pages/events/index.vue
+++ b/pages/events/index.vue
@@ -105,6 +105,8 @@ export default {
               return true;
             }
             return false;
+          }).sort((a, b) => {
+            return new Date(a.date) - new Date(b.date); // Sort upcoming meetups so that the closest one in time is displayed first
           });
       }
     },


### PR DESCRIPTION
I'm not sure if this will do, can you verify?
Basically I think showing the meetups closest in time highest up the page, as they are the most relevant.
cc @kaspernissen @jepp2078 