### PR TITLE
Remove top navigation bar

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,22 +1,6 @@
 <nav class="navbar navbar-expand-md navbar-dark fixed-top bg-gradient">
-      <a class="navbar-brand" href="/"><img src="logo.svg" /></a>
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-      <div class="collapse navbar-collapse" id="navbarCollapse">
-        <ul class="navbar-nav text-uppercase font-weight-bold ml-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="#">Meetup Groups</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Speakers</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Sponsors</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="#">Events</a>
-          </li>
-        </ul>
-      </div>
-    </nav>
+  <a class="navbar-brand" href="/"><img src="logo.svg" /></a>
+  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarCollapse" aria-controls="navbarCollapse" aria-expanded="false" aria-label="Toggle navigation">
+    <span class="navbar-toggler-icon"></span>
+  </button>
+</nav>


### PR DESCRIPTION
This PR removes the top navigation bar as we currently not using them. 

We can always re-add them if we decide to build out the page.

<img width="1430" alt="Screenshot 2021-03-26 at 06 57 26" src="https://user-images.githubusercontent.com/4429108/112588941-88ba7f80-8e00-11eb-9a97-29402ab6018d.png">