### PR TITLE
Change slack invitation to be a link instead of a form

### DIFF
--- a/assets/scss/custom/_style.scss
+++ b/assets/scss/custom/_style.scss
@@ -138,3 +138,24 @@ footer {
         max-width: 2.6rem;
     }
 }
+
+.slack {
+    a:link {
+        color: $blue;
+        text-decoration: underline;
+    }
+
+    a:visited {
+        color: $pink;
+        text-decoration: underline;
+    }
+
+    a:hover {
+        color: $grey;
+        text-decoration: underline;
+    }
+    a:active {
+        color: $blue;
+        text-decoration: underline;
+    }
+}

--- a/layouts/partials/slack.html
+++ b/layouts/partials/slack.html
@@ -1,39 +1,9 @@
-<section class="bg-purple py-4">
+<section class="bg-purple py-4 slack">
   <div class="container">
     <div class="row">
-      <div class="col-sm-12 col-lg-6 align-self-center">
-        <h3>Join our Slack community</h3>
-      </div>
-      <div class="col-sm-12 col-lg-6">
-        <form action="https://slack.cloudnativenordics.com/invite" method="get" class="mb-0">
-          <div class="input-group mb-3">
-            <input type="email" name="email" id="email" class="form-control form-control-lg"
-              placeholder="Enter email..." />
-            <div class="input-group-append">
-              <button type="submit" class="btn btn-secondary" type="button">Invite</button>
-            </div>
-          </div>
-          <div class="cf-turnstile" data-sitekey="0x4AAAAAAAQkG-a3pcOC8Ic1"></div>
-        </form>
-        <p id="status"></p>
+      <div class="col-sm-12 col-lg-12 align-self-center">
+        <h3>Join our Slack community by following <a href="https://join.slack.com/t/cloud-native-nordics/shared_invite/zt-2ge0c6cmo-SDDeFUDeEU~TUkZTDcis8w">this link</a></h3>
       </div>
     </div>
   </div>
 </section>
-<script>
-  (() => {
-    const form = document.querySelector('form');
-    const formResponse = document.getElementById('status');
-    const inputEmail = document.getElementById("email")
-    form.onsubmit = e => {
-      e.preventDefault();
-      var xhr = new XMLHttpRequest();
-      xhr.open(form.method, form.action + "?email=" + inputEmail.value, true);
-      xhr.send(null);
-      xhr.onloadend = response => {
-        form.reset();
-        formResponse.innerHTML = response.target.responseText;
-      };
-    };
-  })();
-</script>


### PR DESCRIPTION
This PR changes the slack invitation to use a static link rather than the form sign-up we had before that currently doesn't work due to the hitting the slack invitations limit. 

<img width="1796" alt="Screenshot 2024-04-10 at 09 43 46" src="https://github.com/cloud-native-nordics/website/assets/4429108/a2bb43e9-2c32-40f2-870a-8a82d14fe28f">
